### PR TITLE
Account for null response in direction matrix

### DIFF
--- a/direction_matrix.go
+++ b/direction_matrix.go
@@ -24,11 +24,11 @@ type DirectionsMatrixRequest struct {
 }
 
 type DirectionsMatrixResponse struct {
-	Code         string      `json:"code"`
-	Durations    [][]float64 `json:"durations"`
-	Distances    [][]float64 `json:"distances"`
-	Destinations []Waypoint  `json:"destinations"`
-	Sources      []Waypoint  `json:"sources"`
+	Code         string       `json:"code"`
+	Durations    [][]*float64 `json:"durations"`
+	Distances    [][]*float64 `json:"distances"`
+	Destinations []Waypoint   `json:"destinations"`
+	Sources      []Waypoint   `json:"sources"`
 }
 
 // https://docs.mapbox.com/api/navigation/#matrix


### PR DESCRIPTION
Differentiate between 0 distance for a valid route and null distance for an invalid route. For example the below request driving from HI to US would look the same but need to be differentiable 

```
curl --location --request GET 'https://api.mapbox.com/directions-matrix/v1/mapbox/driving-traffic/-157.9252,21.32456;-117.193443,32.733810?access_token=XXXXXXXXXX&sources=1&annotations=duration,distance' --header 'Content-Type: application/x-www-form-urlencoded'
```

```
{"code":"Ok","distances":[[null,0.0]],"durations":[[null,0.0]],"destinations":[{"distance":504.227185075,"name":"Worchester Avenue","location":[-157.928653,21.321355]},{"distance":167.228475942,"name":"Guantanamo Street","location":[-117.192949,32.735259]}],"sources":[{"distance":167.228475942,"name":"Guantanamo Street","location":[-117.192949,32.735259]}]}
```