### PR TITLE
Interpolated is a bool

### DIFF
--- a/geocoding.go
+++ b/geocoding.go
@@ -94,7 +94,7 @@ type Properties struct {
 type Geometry struct {
 	Coordinates  []float64 `json:"coordinates"`
 	Type         string    `json:"type"`
-	Interpolated string    `json:"interpolated,omitempty"`
+	Interpolated bool      `json:"interpolated,omitempty"`
 	Omitted      string    `json:"omitted,omitempty"`
 }
 


### PR DESCRIPTION
According to https://docs.mapbox.com/api/search/geocoding/#geocoding-response-object

> `geometry.interpolated` | boolean | Optional. If present, indicates that an address is [interpolated](https://en.wikipedia.org/wiki/Geocoding#Address_interpolation) along a road network. The geocoder can usually return exact address points, but if an address is not present the geocoder can use interpolated data as a fallback. In edge cases, interpolation may not be possible if surrounding address data is not present, in which case the next fallback will be the center point of the street feature itself.


