### PR TITLE
Add depart_at to distance matrix request

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ request := &mapbox.DirectionsMatrixRequest{
     Approaches: mapbox.Approaches{mapbox.ApproachUnrestricted},
     Sources: mapbox.Sources{0},
     FallbackSpeed: 60,
+    DepartureTime: mapbox.DepartureTime(time.Now()),
 }
 
 response, err := mapboxClient.DirectionsMatrix(context.TODO(), request)

--- a/direction_matrix.go
+++ b/direction_matrix.go
@@ -21,6 +21,7 @@ type DirectionsMatrixRequest struct {
 	Destinations  Destinations
 	Sources       Sources
 	FallbackSpeed FallbackSpeed
+	DepartureTime DepartureTime
 }
 
 type DirectionsMatrixResponse struct {
@@ -42,6 +43,7 @@ func directionsMatrix(ctx context.Context, client *Client, req *DirectionsMatrix
 	query.Set("destinations", req.Destinations.query())
 	query.Set("sources", req.Sources.query())
 	query.Set("fallback_speed", req.FallbackSpeed.query())
+	query.Set("depart_at", req.DepartureTime.query())
 
 	apiResponse, err := client.get(ctx, relPath, query)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -152,3 +153,24 @@ func (t Types) strings() []string {
 func (t Types) query() string {
 	return strings.Join(t.strings(), ",")
 }
+
+//////////////////////////////////////////////////////////////////
+
+type DepartureTime time.Time
+
+const (
+	DepartureTimeFormat = "2006-01-02T15:04:05Z"
+)
+
+func (t DepartureTime) IsZero() bool {
+	return time.Time(t).IsZero()
+}
+
+func (t DepartureTime) query() string {
+	if t.IsZero() {
+		return ""
+	}
+	return time.Time(t).UTC().Format(DepartureTimeFormat)
+}
+
+//////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added support for `depart_at` parameter for directions matrix request
https://docs.mapbox.com/api/navigation/matrix/